### PR TITLE
Add a command line option to specify the minimum allowed tile extent

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Options
  * -Z _zoom_: Lowest (minzoom) zoom level (default 0)
  * -d _detail_: Detail at base zoom level (default 26-basezoom, ~0.5m, for tile resolution of 4096 if -z14)
  * -D _detail_: Detail at lower zoom levels (default 10, for tile resolution of 1024)
+ * -m _detail_: Minimum detail that it will try if tiles are too big at regular detail (default 7)
  * -b _pixels_: Buffer size where features are duplicated from adjacent tiles (default 5)
 
 ### Properties

--- a/man/tippecanoe.1
+++ b/man/tippecanoe.1
@@ -76,6 +76,8 @@ it encounters.
 .IP \(bu 2
 \-D \fIdetail\fP: Detail at lower zoom levels (default 10, for tile resolution of 1024)
 .IP \(bu 2
+\-m \fIdetail\fP: Minimum detail that it will try if tiles are too big at regular detail (default 7)
+.IP \(bu 2
 \-b \fIpixels\fP: Buffer size where features are duplicated from adjacent tiles (default 5)
 .RE
 .SS Properties

--- a/tile.cc
+++ b/tile.cc
@@ -25,7 +25,6 @@ extern "C" {
 }
 
 #define CMD_BITS 3
-#define MIN_DETAIL 7
 
 // https://github.com/mapbox/mapnik-vector-tile/blob/master/src/vector_tile_compression.hpp
 static inline int compress(std::string const& input, std::string& output) {
@@ -350,14 +349,14 @@ void evaluate(std::vector<coalesce> &features, char *metabase, struct pool *file
 }
 #endif
 
-long long write_tile(char **geoms, char *metabase, unsigned *file_bbox, int z, unsigned tx, unsigned ty, int detail, int basezoom, struct pool **file_keys, char **layernames, sqlite3 *outdb, double droprate, int buffer, const char *fname, FILE *geomfile[4], int file_minzoom, int file_maxzoom, double todo, char *geomstart, long long along, double gamma, int nlayers, char *prevent) {
+long long write_tile(char **geoms, char *metabase, unsigned *file_bbox, int z, unsigned tx, unsigned ty, int detail, int min_detail, int basezoom, struct pool **file_keys, char **layernames, sqlite3 *outdb, double droprate, int buffer, const char *fname, FILE *geomfile[4], int file_minzoom, int file_maxzoom, double todo, char *geomstart, long long along, double gamma, int nlayers, char *prevent) {
 	int line_detail;
 	static bool evaluated = false;
 	double oprogress = 0;
 
 	char *og = *geoms;
 
-	for (line_detail = detail; line_detail >= MIN_DETAIL || line_detail == detail; line_detail--) {
+	for (line_detail = detail; line_detail >= min_detail || line_detail == detail; line_detail--) {
 		GOOGLE_PROTOBUF_VERIFY_VERSION;
 
 		struct pool keys1[nlayers], values1[nlayers];
@@ -675,7 +674,7 @@ long long write_tile(char **geoms, char *metabase, unsigned *file_bbox, int z, u
 			if (compressed.size() > 500000 && !prevent['k' & 0xFF]) {
 				fprintf(stderr, "tile %d/%u/%u size is %lld with detail %d, >500000    \n", z, tx, ty, (long long) compressed.size(), line_detail);
 
-				if (line_detail == MIN_DETAIL || !evaluated) {
+				if (line_detail == min_detail || !evaluated) {
 					evaluated = true;
 #if 0
 					evaluate(features[0], metabase, file_keys[0], layername, line_detail, compressed.size()); // XXX layer

--- a/tile.h
+++ b/tile.h
@@ -25,4 +25,4 @@ void deserialize_uint(char **f, unsigned *n);
 void deserialize_byte(char **f, signed char *n);
 struct pool_val *deserialize_string(char **f, struct pool *p, int type);
 
-long long write_tile(char **geom, char *metabase, unsigned *file_bbox, int z, unsigned x, unsigned y, int detail, int basezoom, struct pool **file_keys, char **layernames, sqlite3 *outdb, double droprate, int buffer, const char *fname, FILE *geomfile[4], int file_minzoom, int file_maxzoom, double todo, char *geomstart, long long along, double gamma, int nlayers, char *prevent);
+long long write_tile(char **geom, char *metabase, unsigned *file_bbox, int z, unsigned x, unsigned y, int detail, int min_detail, int basezoom, struct pool **file_keys, char **layernames, sqlite3 *outdb, double droprate, int buffer, const char *fname, FILE *geomfile[4], int file_minzoom, int file_maxzoom, double todo, char *geomstart, long long along, double gamma, int nlayers, char *prevent);


### PR DESCRIPTION
So that you can say -d12 -D12 -m12 to force an extent of 4096 in every tile.

@tmcw 