### PR TITLE
Change some defaults that keep tripping people up:

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,13 @@ Options
 
  * -o _file_.mbtiles: Name the output file.
  * -f: Delete the mbtiles file if it already exists instead of giving an error
+ * -t _directory_: Put the temporary files in _directory_.
 
 ### Zoom levels and resolution
 
  * -z _zoom_: Base (maxzoom) zoom level (default 14)
  * -Z _zoom_: Lowest (minzoom) zoom level (default 0)
- * -d _detail_: Detail at base zoom level (default 26-basezoom, ~0.5m, for tile resolution of 4096 if -z14)
+ * -d _detail_: Detail at base zoom level (default 12 at -z14 or higher, or 13 at -z13 or lower. Detail beyond 13 has rendering problems with Mapbox GL.)
  * -D _detail_: Detail at lower zoom levels (default 10, for tile resolution of 1024)
  * -m _detail_: Minimum detail that it will try if tiles are too big at regular detail (default 7)
  * -b _pixels_: Buffer size where features are duplicated from adjacent tiles. Units are "screen pixels"--1/256th of the tile width or height. (default 5)
@@ -82,15 +83,18 @@ Options
  * -r _rate_: Rate at which dots are dropped at lower zoom levels (default 2.5)
  * -g _gamma_: Rate at which especially dense dots are dropped (default 0, for no effect). A gamma of 2 reduces the number of dots less than a pixel apart to the square root of their original number.
 
+### Doing more
+
+ * -ac: Coalesce adjacent line and polygon features that have the same properties
+ * -ar: Try reversing the directions of lines to make them coalesce and compress better
+ * -ao: Reorder features to put ones with the same properties in sequence, to try to get them to coalesce
+ * -al: Let "dot" dropping at lower zooms apply to lines too
+
 ### Doing less
 
  * -ps: Don't simplify lines
- * -pr: Don't reverse the direction of lines to make them coalesce better
- * -pc: Don't coalesce features with the same properties
  * -pf: Don't limit tiles to 200,000 features
  * -pk: Don't limit tiles to 500K bytes
- * -po: Don't reorder features to put the same properties in sequence
- * -pl: Let "dot" simplification apply to lines too
  * -pd: Dynamically drop some fraction of features from large tiles to keep them under the 500K size limit. It will probably look ugly at the tile boundaries.
  * -q: Work quietly instead of reporting progress
 

--- a/man/tippecanoe.1
+++ b/man/tippecanoe.1
@@ -64,6 +64,8 @@ it encounters.
 \-o \fIfile\fP\&.mbtiles: Name the output file.
 .IP \(bu 2
 \-f: Delete the mbtiles file if it already exists instead of giving an error
+.IP \(bu 2
+\-t \fIdirectory\fP: Put the temporary files in \fIdirectory\fP\&.
 .RE
 .SS Zoom levels and resolution
 .RS
@@ -72,7 +74,7 @@ it encounters.
 .IP \(bu 2
 \-Z \fIzoom\fP: Lowest (minzoom) zoom level (default 0)
 .IP \(bu 2
-\-d \fIdetail\fP: Detail at base zoom level (default 26\-basezoom, ~0.5m, for tile resolution of 4096 if \-z14)
+\-d \fIdetail\fP: Detail at base zoom level (default 12 at \-z14 or higher, or 13 at \-z13 or lower. Detail beyond 13 has rendering problems with Mapbox GL.)
 .IP \(bu 2
 \-D \fIdetail\fP: Detail at lower zoom levels (default 10, for tile resolution of 1024)
 .IP \(bu 2
@@ -96,22 +98,25 @@ it encounters.
 .IP \(bu 2
 \-g \fIgamma\fP: Rate at which especially dense dots are dropped (default 0, for no effect). A gamma of 2 reduces the number of dots less than a pixel apart to the square root of their original number.
 .RE
+.SS Doing more
+.RS
+.IP \(bu 2
+\-ac: Coalesce adjacent line and polygon features that have the same properties
+.IP \(bu 2
+\-ar: Try reversing the directions of lines to make them coalesce and compress better
+.IP \(bu 2
+\-ao: Reorder features to put ones with the same properties in sequence, to try to get them to coalesce
+.IP \(bu 2
+\-al: Let "dot" dropping at lower zooms apply to lines too
+.RE
 .SS Doing less
 .RS
 .IP \(bu 2
 \-ps: Don't simplify lines
 .IP \(bu 2
-\-pr: Don't reverse the direction of lines to make them coalesce better
-.IP \(bu 2
-\-pc: Don't coalesce features with the same properties
-.IP \(bu 2
 \-pf: Don't limit tiles to 200,000 features
 .IP \(bu 2
 \-pk: Don't limit tiles to 500K bytes
-.IP \(bu 2
-\-po: Don't reorder features to put the same properties in sequence
-.IP \(bu 2
-\-pl: Let "dot" simplification apply to lines too
 .IP \(bu 2
 \-pd: Dynamically drop some fraction of features from large tiles to keep them under the 500K size limit. It will probably look ugly at the tile boundaries.
 .IP \(bu 2
@@ -167,7 +172,7 @@ I don't know why 2.5 is the appropriate number, but the densities of many differ
 data sets fall off at about this same rate. You can use \-r to specify a different rate.
 .PP
 You can use the gamma option to thin out especially dense clusters of points.
-For any area that where dots are closer than one pixel together (at whatever zoom level),
+For any area where dots are closer than one pixel together (at whatever zoom level),
 a gamma of 3, for example, will reduce these clusters to the cube root of their original density.
 .PP
 For line features, it drops any features that are too small to draw at all.

--- a/tile.cc
+++ b/tile.cc
@@ -451,7 +451,7 @@ void rewrite(drawvec &geom, int z, int nextzoom, int file_maxzoom, long long *bb
 	}
 }
 
-long long write_tile(char **geoms, char *metabase, char *stringpool, unsigned *file_bbox, int z, unsigned tx, unsigned ty, int detail, int min_detail, int basezoom, struct pool **file_keys, char **layernames, sqlite3 *outdb, double droprate, int buffer, const char *fname, FILE **geomfile, int file_minzoom, int file_maxzoom, double todo, char *geomstart, long long along, double gamma, int nlayers, char *prevent) {
+long long write_tile(char **geoms, char *metabase, char *stringpool, unsigned *file_bbox, int z, unsigned tx, unsigned ty, int detail, int min_detail, int basezoom, struct pool **file_keys, char **layernames, sqlite3 *outdb, double droprate, int buffer, const char *fname, FILE **geomfile, int file_minzoom, int file_maxzoom, double todo, char *geomstart, long long along, double gamma, int nlayers, char *prevent, char *additional) {
 	int line_detail;
 	static bool evaluated = false;
 	double oprogress = 0;
@@ -580,7 +580,7 @@ long long write_tile(char **geoms, char *metabase, char *stringpool, unsigned *f
 				continue;
 			}
 
-			if (gamma >= 0 && (t == VT_POINT || (prevent['l' & 0xFF] && t == VT_LINE))) {
+			if (gamma >= 0 && (t == VT_POINT || (additional['l' & 0xFF] && t == VT_LINE))) {
 				seq++;
 				if (seq >= 0) {
 					seq -= interval;
@@ -645,7 +645,7 @@ long long write_tile(char **geoms, char *metabase, char *stringpool, unsigned *f
 			}
 #endif
 
-			if (t == VT_LINE && !prevent['r' & 0xFF]) {
+			if (t == VT_LINE && additional['r' & 0xFF]) {
 				geom = reorder_lines(geom);
 			}
 
@@ -687,7 +687,7 @@ long long write_tile(char **geoms, char *metabase, char *stringpool, unsigned *f
 		}
 
 		for (j = 0; j < nlayers; j++) {
-			if (!prevent['o' & 0xFF]) {
+			if (additional['o' & 0xFF]) {
 				std::sort(features[j].begin(), features[j].end());
 			}
 
@@ -702,7 +702,7 @@ long long write_tile(char **geoms, char *metabase, char *stringpool, unsigned *f
 				}
 #endif
 
-				if (!prevent['c' & 0xFF] && out.size() > 0 && out[y].geom.size() + features[j][x].geom.size() < 20000 && coalcmp(&features[j][x], &out[y]) == 0 && features[j][x].type != VT_POINT) {
+				if (additional['c' & 0xFF] && out.size() > 0 && out[y].geom.size() + features[j][x].geom.size() < 20000 && coalcmp(&features[j][x], &out[y]) == 0 && features[j][x].type != VT_POINT) {
 					unsigned z;
 					for (z = 0; z < features[j][x].geom.size(); z++) {
 						out[y].geom.push_back(features[j][x].geom[z]);
@@ -794,7 +794,7 @@ long long write_tile(char **geoms, char *metabase, char *stringpool, unsigned *f
 	return -1;
 }
 
-int traverse_zooms(int *geomfd, off_t *geom_size, char *metabase, char *stringpool, unsigned *file_bbox, struct pool **file_keys, unsigned *midx, unsigned *midy, char **layernames, int maxzoom, int minzoom, sqlite3 *outdb, double droprate, int buffer, const char *fname, const char *tmpdir, double gamma, int nlayers, char *prevent, int full_detail, int low_detail, int min_detail) {
+int traverse_zooms(int *geomfd, off_t *geom_size, char *metabase, char *stringpool, unsigned *file_bbox, struct pool **file_keys, unsigned *midx, unsigned *midy, char **layernames, int maxzoom, int minzoom, sqlite3 *outdb, double droprate, int buffer, const char *fname, const char *tmpdir, double gamma, int nlayers, char *prevent, char *additional, int full_detail, int low_detail, int min_detail) {
 	int i;
 	for (i = 0; i <= maxzoom; i++) {
 		long long most = 0;
@@ -855,7 +855,7 @@ int traverse_zooms(int *geomfd, off_t *geom_size, char *metabase, char *stringpo
 
 				// fprintf(stderr, "%d/%u/%u\n", z, x, y);
 
-				long long len = write_tile(&geom, metabase, stringpool, file_bbox, z, x, y, z == maxzoom ? full_detail : low_detail, min_detail, maxzoom, file_keys, layernames, outdb, droprate, buffer, fname, sub, minzoom, maxzoom, todo, geomstart, along, gamma, nlayers, prevent);
+				long long len = write_tile(&geom, metabase, stringpool, file_bbox, z, x, y, z == maxzoom ? full_detail : low_detail, min_detail, maxzoom, file_keys, layernames, outdb, droprate, buffer, fname, sub, minzoom, maxzoom, todo, geomstart, along, gamma, nlayers, prevent, additional);
 
 				if (len < 0) {
 					return i - 1;

--- a/tile.h
+++ b/tile.h
@@ -25,9 +25,9 @@ void deserialize_uint(char **f, unsigned *n);
 void deserialize_byte(char **f, signed char *n);
 struct pool_val *deserialize_string(char **f, struct pool *p, int type);
 
-long long write_tile(char **geom, char *metabase, char *stringpool, unsigned *file_bbox, int z, unsigned x, unsigned y, int detail, int min_detail, int basezoom, struct pool **file_keys, char **layernames, sqlite3 *outdb, double droprate, int buffer, const char *fname, FILE **geomfile, int file_minzoom, int file_maxzoom, double todo, char *geomstart, long long along, double gamma, int nlayers, char *prevent);
+long long write_tile(char **geom, char *metabase, char *stringpool, unsigned *file_bbox, int z, unsigned x, unsigned y, int detail, int min_detail, int basezoom, struct pool **file_keys, char **layernames, sqlite3 *outdb, double droprate, int buffer, const char *fname, FILE **geomfile, int file_minzoom, int file_maxzoom, double todo, char *geomstart, long long along, double gamma, int nlayers, char *prevent, char *additional);
 
-int traverse_zooms(int *geomfd, off_t *geom_size, char *metabase, char *stringpool, unsigned *file_bbox, struct pool **file_keys, unsigned *midx, unsigned *midy, char **layernames, int maxzoom, int minzoom, sqlite3 *outdb, double droprate, int buffer, const char *fname, const char *tmpdir, double gamma, int nlayers, char *prevent, int full_detail, int low_detail, int min_detail);
+int traverse_zooms(int *geomfd, off_t *geom_size, char *metabase, char *stringpool, unsigned *file_bbox, struct pool **file_keys, unsigned *midx, unsigned *midy, char **layernames, int maxzoom, int minzoom, sqlite3 *outdb, double droprate, int buffer, const char *fname, const char *tmpdir, double gamma, int nlayers, char *prevent, char *additional, int full_detail, int low_detail, int min_detail);
 
 extern unsigned initial_x, initial_y;
 extern int geometry_scale;


### PR DESCRIPTION
* Default detail with low -z is only 13, so it works with GL
* No coalescing, line-reversing, or reordering by attributes except by request
* Dropping lines like points moves from -d to -a