### PR TITLE
Update clipper to 9edc2924e39:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.2
+
+* Update Clipper to fix potential crash
+
 ## 1.11.1
 
 * Make better use of C++ standard libraries

--- a/clipper/clipper.cpp
+++ b/clipper/clipper.cpp
@@ -4643,7 +4643,7 @@ bool Clipper::FindIntersectLoop(std::unordered_multimap<int, OutPtIntersect> & d
     range = dupeRec.equal_range(idx_search);
     visited.insert(idx_search);
     // Check for connection through chain of other intersections
-    for (auto it = range.first; it != range.second; ++it)
+    for (auto it = range.first; it != range.second && it != dupeRec.end() && it->first == idx_search; ++it)
     {
         OutRec * itRec = GetOutRec(it->second.op2->Idx);
         if (visited.count(itRec->Idx) > 0 || 
@@ -4741,7 +4741,7 @@ bool Clipper::FixIntersects(std::unordered_multimap<int, OutPtIntersect> & dupeR
         std::set<int> visited;
         visited.insert(outRec_search->Idx);
         // Check for connection through chain of other intersections
-        for (auto it = range.first; it != range.second; ++it)
+        for (auto it = range.first; it != range.second && it != dupeRec.end() && it->first == outRec_search->Idx; ++it)
         {
             OutRec * itRec = GetOutRec(it->second.op2->Idx);
             if (itRec->Idx != outRec_search->Idx &&

--- a/version.hpp
+++ b/version.hpp
@@ -1,1 +1,1 @@
-#define VERSION "tippecanoe v1.11.1\n"
+#define VERSION "tippecanoe v1.11.2\n"


### PR DESCRIPTION
commit 9edc2924e39266d70774b0ed0e07329a95e76f10
Author: Blake Thompson <flippmoke@gmail.com>
Date:   Mon May 2 14:45:21 2016 -0400

	Updated to prevent segfault in case where specific iterator was being deleted
	and therefore, the range second no longer existed.