### PR TITLE
Geometry.hpp c++11 improvements

### DIFF
--- a/decode.cpp
+++ b/decode.cpp
@@ -193,9 +193,9 @@ void handle(std::string message, int z, unsigned x, unsigned y, int describe) {
 					double lat, lon;
 					tile2latlon(wx, wy, 32, &lat, &lon);
 
-					ops.push_back(lonlat(op, lon, lat, px, py));
+					ops.emplace_back(op, lon, lat, px, py);
 				} else {
-					ops.push_back(lonlat(op, 0, 0, 0, 0));
+					ops.emplace_back(op, 0, 0, 0, 0);
 				}
 			}
 
@@ -254,8 +254,8 @@ void handle(std::string message, int z, unsigned x, unsigned y, int describe) {
 
 				for (size_t i = 0; i < ops.size(); i++) {
 					if (ops[i].op == VT_MOVETO) {
-						rings.push_back(std::vector<lonlat>());
-						areas.push_back(0);
+						rings.emplace_back();
+						areas.emplace_back(0);
 					}
 
 					int n = rings.size() - 1;

--- a/geometry.cpp
+++ b/geometry.cpp
@@ -108,7 +108,7 @@ mapbox::geometry::geometry<long long> from_drawvec(int type, drawvec const& dv) 
 		} else {
 			mapbox::geometry::multi_point<long long> mp;
 			for (size_t i = 0; i < dv.size(); i++) {
-				mp.push_back(mapbox::geometry::point<long long>(dv[i].x, dv[i].y));
+				mp.emplace_back((long long)dv[i].x, (long long)dv[i].y);
 			}
 			return mp;
 		}
@@ -122,7 +122,7 @@ mapbox::geometry::geometry<long long> from_drawvec(int type, drawvec const& dv) 
 		if (movetos == 1) {
 			mapbox::geometry::line_string<long long> ls;
 			for (size_t i = 0; i < dv.size(); i++) {
-				ls.push_back(mapbox::geometry::point<long long>(dv[i].x, dv[i].y));
+				ls.emplace_back((long long)dv[i].x, (long long)dv[i].y);
 			}
 			return ls;
 		} else {
@@ -137,7 +137,7 @@ mapbox::geometry::geometry<long long> from_drawvec(int type, drawvec const& dv) 
 					}
 					mapbox::geometry::line_string<long long> ls;
 					for (size_t k = i; k < j; k++) {
-						ls.push_back(mapbox::geometry::point<long long>(dv[k].x, dv[k].y));
+						ls.emplace_back((long long)dv[k].x, (long long)dv[k].y);
 					}
 					mls.push_back(ls);
 					i = j - 1;
@@ -177,7 +177,7 @@ mapbox::geometry::geometry<long long> from_drawvec(int type, drawvec const& dv) 
 			for (size_t i = 0; i < rings.size(); i++) {
 				mapbox::geometry::linear_ring<long long> lr;
 				for (size_t j = 0; j < rings[i].size(); j++) {
-					lr.push_back(mapbox::geometry::point<long long>(rings[i][j].x, rings[i][j].y));
+					lr.emplace_back((long long)rings[i][j].x, (long long)rings[i][j].y);
 				}
 				p.push_back(lr);
 			}
@@ -190,7 +190,7 @@ mapbox::geometry::geometry<long long> from_drawvec(int type, drawvec const& dv) 
 				}
 				mapbox::geometry::linear_ring<long long> lr;
 				for (size_t j = 0; j < rings[i].size(); j++) {
-					lr.push_back(mapbox::geometry::point<long long>(rings[i][j].x, rings[i][j].y));
+					lr.emplace_back((long long)rings[i][j].x, (long long)rings[i][j].y);
 				}
 				mp[mp.size() - 1].push_back(lr);
 			}

--- a/geometry.cpp
+++ b/geometry.cpp
@@ -14,7 +14,6 @@
 #include "projection.hpp"
 #include "serial.hpp"
 #include "main.hpp"
-#include <mapbox/geometry/feature.hpp>
 
 struct convert_visitor {
 	drawvec *dv;

--- a/geometry.cpp
+++ b/geometry.cpp
@@ -187,7 +187,7 @@ mapbox::geometry::geometry<long long> from_drawvec(int type, drawvec dv) {
 			mapbox::geometry::multi_polygon<long long> mp;
 			for (size_t i = 0; i < rings.size(); i++) {
 				if (areas[i] >= 0 || i == 0) {
-					mp.push_back(mapbox::geometry::polygon<long long>());
+					mp.emplace_back();
 				}
 				mapbox::geometry::linear_ring<long long> lr;
 				for (size_t j = 0; j < rings[i].size(); j++) {

--- a/geometry.cpp
+++ b/geometry.cpp
@@ -24,19 +24,19 @@ struct convert_visitor {
 		type = ntype;
 	}
 
-	void operator()(mapbox::geometry::point<long long> &val) const {
+	void operator()(mapbox::geometry::point<long long> const& val) const {
 		*type = VT_POINT;
 		dv->push_back(draw(VT_MOVETO, val.x, val.y));
 	}
 
-	void operator()(mapbox::geometry::multi_point<long long> &val) const {
+	void operator()(mapbox::geometry::multi_point<long long> const& val) const {
 		*type = VT_POINT;
 		for (size_t i = 0; i < val.size(); i++) {
 			dv->push_back(draw(VT_MOVETO, val[i].x, val[i].y));
 		}
 	}
 
-	void operator()(mapbox::geometry::line_string<long long> &val) const {
+	void operator()(mapbox::geometry::line_string<long long> const& val) const {
 		*type = VT_LINE;
 		for (size_t i = 0; i < val.size(); i++) {
 			if (i == 0) {
@@ -47,7 +47,7 @@ struct convert_visitor {
 		}
 	}
 
-	void operator()(mapbox::geometry::multi_line_string<long long> &val) const {
+	void operator()(mapbox::geometry::multi_line_string<long long> const& val) const {
 		*type = VT_LINE;
 		for (size_t i = 0; i < val.size(); i++) {
 			for (size_t j = 0; j < val[i].size(); j++) {
@@ -60,7 +60,7 @@ struct convert_visitor {
 		}
 	}
 
-	void operator()(mapbox::geometry::polygon<long long> &val) const {
+	void operator()(mapbox::geometry::polygon<long long> const& val) const {
 		*type = VT_POLYGON;
 		for (size_t i = 0; i < val.size(); i++) {
 			for (size_t j = 0; j < val[i].size(); j++) {
@@ -73,7 +73,7 @@ struct convert_visitor {
 		}
 	}
 
-	void operator()(mapbox::geometry::multi_polygon<long long> &val) const {
+	void operator()(mapbox::geometry::multi_polygon<long long> const& val) const {
 		*type = VT_POLYGON;
 		for (size_t i = 0; i < val.size(); i++) {
 			for (size_t j = 0; j < val[i].size(); j++) {
@@ -88,20 +88,20 @@ struct convert_visitor {
 		}
 	}
 
-	void operator()(mapbox::geometry::geometry_collection<long long> &val) const {
+	void operator()(mapbox::geometry::geometry_collection<long long> const& val) const {
 		fprintf(stderr, "Geometry collections not supported\n");
 		exit(EXIT_FAILURE);
 	}
 };
 
-drawvec to_drawvec(mapbox::geometry::geometry<long long> g, int &type) {
+drawvec to_drawvec(mapbox::geometry::geometry<long long> const& g, int &type) {
 	drawvec dv;
 	mapbox::util::apply_visitor(convert_visitor(&dv, &type), g);
 
 	return dv;
 }
 
-mapbox::geometry::geometry<long long> from_drawvec(int type, drawvec dv) {
+mapbox::geometry::geometry<long long> from_drawvec(int type, drawvec const& dv) {
 	if (type == VT_POINT) {
 		if (dv.size() == 1) {
 			return mapbox::geometry::point<long long>(dv[0].x, dv[0].y);
@@ -1232,8 +1232,8 @@ mapbox::geometry::multi_line_string<long long> clip_lines(mapbox::geometry::mult
 
 			if (c > 1) {  // clipped
 				out.emplace_back();
-				out[out.size() - 1].push_back(mapbox::geometry::point<long long>(x1, y1));
-				out[out.size() - 1].push_back(mapbox::geometry::point<long long>(x2, y2));
+				out[out.size() - 1].emplace_back(x1, y1);
+				out[out.size() - 1].emplace_back(x2, y2);
 
 				out.emplace_back();
 				out[out.size() - 1].push_back(geom[i][j + 1]);

--- a/geometry.hpp
+++ b/geometry.hpp
@@ -50,6 +50,6 @@ std::vector<drawvec> chop_polygon(std::vector<drawvec> &geoms);
 void check_polygon(drawvec &geom, drawvec &before);
 double get_area(drawvec &geom, size_t i, size_t j);
 
-drawvec to_drawvec(mapbox::geometry::geometry<long long> g, int &type);
-mapbox::geometry::geometry<long long> from_drawvec(int type, drawvec dv);
+drawvec to_drawvec(mapbox::geometry::geometry<long long> const& g, int &type);
+mapbox::geometry::geometry<long long> from_drawvec(int type, drawvec const& dv);
 mapbox::geometry::geometry<long long> clip(mapbox::geometry::geometry<long long> const &g, int z, int line_detail, int buffer);

--- a/geometry.hpp
+++ b/geometry.hpp
@@ -1,3 +1,6 @@
+#include <mapbox/geometry/geometry.hpp>
+#include <cstdint>
+
 #define VT_POINT 1
 #define VT_LINE 2
 #define VT_POLYGON 3
@@ -46,8 +49,6 @@ drawvec fix_polygon(drawvec &geom);
 std::vector<drawvec> chop_polygon(std::vector<drawvec> &geoms);
 void check_polygon(drawvec &geom, drawvec &before);
 double get_area(drawvec &geom, size_t i, size_t j);
-
-#include <mapbox/geometry/feature.hpp>
 
 drawvec to_drawvec(mapbox::geometry::geometry<long long> g, int &type);
 mapbox::geometry::geometry<long long> from_drawvec(int type, drawvec dv);

--- a/tile.cpp
+++ b/tile.cpp
@@ -41,7 +41,7 @@ std::vector<mvt_geometry> to_feature(drawvec &geom) {
 	std::vector<mvt_geometry> out;
 
 	for (size_t i = 0; i < geom.size(); i++) {
-		out.push_back(mvt_geometry(geom[i].op, geom[i].x, geom[i].y));
+		out.emplace_back(geom[i].op, (long long)geom[i].x, (long long)geom[i].y);
 	}
 
 	return out;
@@ -603,9 +603,7 @@ long long write_tile(FILE *geoms, long long *geompos_in, char *metabase, char *s
 
 		std::vector<struct partial> partials;
 		std::vector<std::vector<coalesce> > features;
-		for (int i = 0; i < nlayers; i++) {
-			features.push_back(std::vector<coalesce>());
-		}
+		features.resize(nlayers);
 
 		int within[child_shards];
 		long long geompos[child_shards];


### PR DESCRIPTION
Started looking through the geometry-hpp branch to learn the code. In the process I converted a few  `push_back` usages to `emplace_back` which should avoid copies.