### PR TITLE
Add -Werror

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CXX := $(CXX)
 CFLAGS := $(CFLAGS)
 CXXFLAGS := $(CXXFLAGS) -std=c++11
 LDFLAGS := $(LDFLAGS)
-WARNING_FLAGS := -Wall -Wshadow -Wsign-compare
+WARNING_FLAGS := -Wall -Wshadow -Wsign-compare -Werror
 RELEASE_FLAGS := -O3 -DNDEBUG
 DEBUG_FLAGS := -O0 -DDEBUG -fno-inline-functions -fno-omit-frame-pointer
 


### PR DESCRIPTION
If we add `-Werror` and clean up all the warnings we currently see with all compilers on travis, then going forward we'd be less likely to ignore warnings that arise in new code that might contain bugs.

Both wagyu and mbgl have successfully fixed all warnings to allow them to default to building with `-Werror`. I think tippecanoe is capable of this too.

If users downstream using different compilers hit new warnings we could consider making it a build option to disable. But I think user reports of compile errors for new warnings is better than not knowing about them.