### PR TITLE
Add basic support for Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Don't copy Dockerfile or git items
+.gitignore
+.git
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Start from ubuntu
+FROM ubuntu:17.04
+
+# Update repos and install dependencies
+RUN apt-get update \
+  && apt-get -y upgrade \
+  && apt-get -y install build-essential libsqlite3-dev zlib1g-dev
+
+# Create a directory and copy in all files
+RUN mkdir -p /tmp/tippecanoe-src
+WORKDIR /tmp/tippecanoe-src
+COPY . /tmp/tippecanoe-src
+
+# Build tippecanoe
+RUN make \
+  && make install
+
+# Remove the temp directory and unneeded packages
+WORKDIR /
+RUN rm -rf /tmp/tippecanoe-src \
+  && apt-get -y remove --purge build-essential && apt-get -y autoremove
+
+# Run the default command to show usage
+CMD tippecanoe --help

--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ You can concatenate multiple GeoJSON features or files together,
 and it will parse out the features and ignore whatever other objects
 it encounters.
 
+Docker Image
+------------
+
+A tippecanoe Docker image can be built from source and executed as a task to
+automatically install dependencies and allow tippecanoe to run on any system
+supported by Docker.
+
+```docker
+$ docker build -t tippecanoe:latest .
+$ docker run -it --rm \
+  -v /tiledata:/data \
+  tippecanoe:latest \
+  tippecanoe --output=/data/output.mbtiles /data/example.geojson
+```
+
+The commands above will build a Docker image from the source and compile the
+latest version. The image supports all tippecanoe flags and options.
+
 Options
 -------
 


### PR DESCRIPTION
Based on feature request #373 I have added a Dockerfile, .dockerignore, and documentation in the README to support easily creating and running tippecanoe as a docker task.

I hope this is helpful, I have been running it as a Docker task so seeing others ask for the feature I figured I'd add my Docker config.

If needed this can be setup as an automated build.