### PR TITLE
Port fix for array index out of bounds in decimal conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.26.4
+
+* Array bounds bug fix in binary to decimal conversion library
+
 ## 1.26.3
 
 * Guard against impossible coordinates when decoding tilesets

--- a/milo/dtoa_milo.h
+++ b/milo/dtoa_milo.h
@@ -284,7 +284,8 @@ inline void DigitGen(const DiyFp& W, const DiyFp& Mp, uint64_t delta, std::strin
 		kappa--;
 		if (p2 < delta) {
 			*K += kappa;
-			GrisuRound(buffer, *len, delta, p2, one.f, wp_w.f * kPow10[-kappa]);
+			int index = -static_cast<int>(kappa);
+			GrisuRound(buffer, *len, delta, p2, one.f, wp_w.f * (index < 9 ? kPow10[-static_cast<int>(kappa)] : 0));
 			return;
 		}
 	}

--- a/version.hpp
+++ b/version.hpp
@@ -1,6 +1,6 @@
 #ifndef VERSION_HPP
 #define VERSION_HPP
 
-#define VERSION "tippecanoe v1.26.3\n"
+#define VERSION "tippecanoe v1.26.4\n"
 
 #endif


### PR DESCRIPTION
https://github.com/miloyip/dtoa-benchmark/issues/7

commit fe550f38669fe0f488926c1ef0feb6c101f586d6
Author: Eli Fidler <efidler@topologyinc.com>
Date:   Tue May 31 11:51:37 2016 -0400

    avoid array index out-of-bounds

    UBSAN gave "runtime error: index 13 out of bounds for type 'const uint32_t [10]'"