### PR TITLE
Fix Release file not found error when execute docker build command. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start from ubuntu
-FROM ubuntu:17.04
+FROM ubuntu:16.04
 
 # Update repos and install dependencies
 RUN apt-get update \


### PR DESCRIPTION
Hi,

I fixed an error that occurred when I executed `docker build` command.

```
docker build -t tippecanoe:latest .
```

```
Sending build context to Docker daemon  77.97MB
Step 1/7 : FROM ubuntu:17.04
17.04: Pulling from library/ubuntu
c2ca09a1934b: Pull complete
d6c3619d2153: Pull complete
0efe07335a04: Pull complete
6b1bb01b3a3b: Pull complete
43a98c187399: Pull complete
Digest: sha256:5d41c289942008211c2964bca72800f5c9d5ea5aa4057528da617fb36463d4ab
Status: Downloaded newer image for ubuntu:17.04
 ---> fe1cc5b91830
Step 2/7 : RUN apt-get update   && apt-get -y upgrade   && apt-get -y install build-essential libsqlite3-dev zlib1g-dev
 ---> Running in e3a7b2ed872f
Ign:1 http://archive.ubuntu.com/ubuntu zesty InRelease
Ign:2 http://security.ubuntu.com/ubuntu zesty-security InRelease
...
Ign:43 http://archive.ubuntu.com/ubuntu zesty-backports/multiverse all Packages
Reading package lists...
W: The repository 'http://security.ubuntu.com/ubuntu zesty-security Release' does not have a Release file.
W: The repository 'http://archive.ubuntu.com/ubuntu zesty Release' does not have a Release file.
W: The repository 'http://archive.ubuntu.com/ubuntu zesty-updates Release' does not have a Release file.
W: The repository 'http://archive.ubuntu.com/ubuntu zesty-backports Release' does not have a Release file.
E: Failed to fetch http://security.ubuntu.com/ubuntu/dists/zesty-security/universe/source/Sources  404  Not Found [IP: 91.189.88.149 80]
E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/zesty/universe/source/Sources  404  Not Found [IP: 91.189.88.152 80]
E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/zesty-updates/universe/source/Sources  404  Not Found [IP: 91.189.88.152 80]
E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/zesty-backports/main/binary-amd64/Packages  404  Not Found [IP: 91.189.88.152 80]
E: Some index files failed to download. They have been ignored, or old ones used instead.
The command '/bin/sh -c apt-get update   && apt-get -y upgrade   && apt-get -y install build-essential libsqlite3-dev zlib1g-dev' returned a non-zero code: 100
```

Because Ubuntu 17.04 has reached its end of life.

>Ubuntu 17.04 will be supported for 9 months until January 2018. If you need Long Term Support, it is recommended you use Ubuntu 16.04 LTS instead. 

https://wiki.ubuntu.com/ZestyZapus/ReleaseNotes