### PR TITLE
Use an exit status of 100 if some but not all zoom levels succeeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.27.14
+
+* Use an exit status of 100 if some zoom levels were successfully
+  written but not all zoom levels could be tiled.
+
 ## 1.27.13
 
 * Allow filtering features by zoom level in conditional expressions

--- a/main.cpp
+++ b/main.cpp
@@ -2156,9 +2156,14 @@ int read_input(std::vector<source> &sources, char *fname, int maxzoom, int minzo
 	int written = traverse_zooms(fd, size, meta, stringpool, &midx, &midy, maxzoom, minzoom, outdb, outdir, buffer, fname, tmpdir, gamma, full_detail, low_detail, min_detail, meta_off, pool_off, initial_x, initial_y, simplification, layermaps, prefilter, postfilter, attribute_accum, filter);
 
 	if (maxzoom != written) {
-		fprintf(stderr, "\n\n\n*** NOTE TILES ONLY COMPLETE THROUGH ZOOM %d ***\n\n\n", written);
-		maxzoom = written;
-		ret = EXIT_FAILURE;
+		if (written > minzoom) {
+			fprintf(stderr, "\n\n\n*** NOTE TILES ONLY COMPLETE THROUGH ZOOM %d ***\n\n\n", written);
+			maxzoom = written;
+			ret = 100;
+		} else {
+			fprintf(stderr, "%s: No zoom levels were successfully written\n", *av);
+			exit(EXIT_FAILURE);
+		}
 	}
 
 	madvise(meta, metapos, MADV_DONTNEED);

--- a/version.hpp
+++ b/version.hpp
@@ -1,6 +1,6 @@
 #ifndef VERSION_HPP
 #define VERSION_HPP
 
-#define VERSION "tippecanoe v1.27.13\n"
+#define VERSION "tippecanoe v1.27.14\n"
 
 #endif


### PR DESCRIPTION
This will allow scripts that invoke Tippecanoe to know whether it is worth retaining the output or whether nothing of value was produced.