### PR TITLE
Also take note of --force-feature-limit if extending zooms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.27.15
+
+* --extend-zooms-if-still-dropping now also extends zooms if features
+  are dropped by --force-feature-limit
+
 ## 1.27.14
 
 * Use an exit status of 100 if some zoom levels were successfully

--- a/tile.cpp
+++ b/tile.cpp
@@ -2314,6 +2314,8 @@ long long write_tile(FILE *geoms, long long *geompos_in, char *metabase, char *s
 					if ((additional[A_DROP_FRACTION_AS_NEEDED] || additional[A_COALESCE_FRACTION_AS_NEEDED]) && fraction < arg->fraction_out) {
 						arg->fraction_out = fraction;
 						arg->still_dropping = true;
+					} else if (prevent[P_DYNAMIC_DROP]) {
+						arg->still_dropping = true;
 					}
 					line_detail++;  // to keep it the same when the loop decrements it
 					continue;
@@ -2403,6 +2405,8 @@ long long write_tile(FILE *geoms, long long *geompos_in, char *metabase, char *s
 					}
 					if ((additional[A_DROP_FRACTION_AS_NEEDED] || additional[A_COALESCE_FRACTION_AS_NEEDED]) && fraction < arg->fraction_out) {
 						arg->fraction_out = fraction;
+						arg->still_dropping = true;
+					} else if (prevent[P_DYNAMIC_DROP]) {
 						arg->still_dropping = true;
 					}
 					line_detail++;  // to keep it the same when the loop decrements it

--- a/version.hpp
+++ b/version.hpp
@@ -1,6 +1,6 @@
 #ifndef VERSION_HPP
 #define VERSION_HPP
 
-#define VERSION "tippecanoe v1.27.14\n"
+#define VERSION "tippecanoe v1.27.15\n"
 
 #endif


### PR DESCRIPTION
For https://github.com/mapbox/tippecanoe/issues/563

Previously, `--extend-zooms-if-still-dropping` would extend zooms if features were being dropped for one of the `--…-as-needed` options but not if they were being dropped on a per-tile basis by `--force-feature-limit`.