### PR TITLE
fix: round to [-180, 180]

### DIFF
--- a/projection.cpp
+++ b/projection.cpp
@@ -24,7 +24,7 @@ void lonlat2tile(double lon, double lat, int zoom, long long *x, long long *y) {
 		lat = 89.9;
 	}
 	if (lon_class == FP_INFINITE || lon_class == FP_NAN) {
-		lon = 360;
+		lon = 180;
 	}
 
 	// Must limit latitude somewhere to prevent overflow.
@@ -37,11 +37,11 @@ void lonlat2tile(double lon, double lat, int zoom, long long *x, long long *y) {
 		lat = 89.9;
 	}
 
-	if (lon < -360) {
-		lon = -360;
+	if (lon < -180) {
+		lon = -180;
 	}
-	if (lon > 360) {
-		lon = 360;
+	if (lon > 180) {
+		lon = 180;
 	}
 
 	double lat_rad = lat * M_PI / 180;


### PR DESCRIPTION
I think lon should between -180 and 180. Otherwise, `(lon + 180) / 360` would exceed 1.