### PR TITLE
Make tile-join and tippecanoe-decode more flexible about directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.32.11
+
+* Accept .mvt as well as .pbf in directories of tiles
+* Allow tippecanoe-decode and tile-join of directories with no metadata
+
 ## 1.32.10
 
 * Fix a bug that disallowed a per-feature minzoom of 0

--- a/dirtiles.hpp
+++ b/dirtiles.hpp
@@ -1,5 +1,6 @@
 #include <string>
 #include <vector>
+#include <sys/stat.h>
 
 #ifndef DIRTILES_HPP
 #define DIRTILES_HPP
@@ -12,6 +13,7 @@ struct zxy {
 	long long z;
 	long long x;
 	long long y;
+	std::string extension = ".pbf";
 
 	zxy(int _z, int _x, int _y)
 	    : z(_z), x(_x), y(_y) {
@@ -36,7 +38,7 @@ struct zxy {
 	}
 
 	std::string path() {
-		return std::to_string(z) + "/" + std::to_string(x) + "/" + std::to_string(y) + ".pbf";
+		return std::to_string(z) + "/" + std::to_string(x) + "/" + std::to_string(y) + extension;
 	}
 };
 

--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -1092,6 +1092,15 @@ int main(int argc, char **argv) {
 		name = set_name;
 	}
 
+	for (auto &l : layermap) {
+		if (l.second.minzoom < st.minzoom) {
+			st.minzoom = l.second.minzoom;
+		}
+		if (l.second.maxzoom > st.maxzoom) {
+			st.maxzoom = l.second.maxzoom;
+		}
+	}
+
 	mbtiles_write_metadata(outdb, out_dir, name.c_str(), st.minzoom, st.maxzoom, st.minlat, st.minlon, st.maxlat, st.maxlon, st.midlat, st.midlon, 0, attribution.size() != 0 ? attribution.c_str() : NULL, layermap, true, description.c_str(), !pg, attribute_descriptions, "tile-join");
 
 	if (outdb != NULL) {

--- a/version.hpp
+++ b/version.hpp
@@ -1,6 +1,6 @@
 #ifndef VERSION_HPP
 #define VERSION_HPP
 
-#define VERSION "v1.32.10"
+#define VERSION "v1.32.11"
 
 #endif


### PR DESCRIPTION
* Accept .mvt as well as .pbf in directories of tiles
* Allow tippecanoe-decode and tile-join of directories with no metadata