### PR TITLE
Add missing Make dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ SHELL = /bin/bash
 # inherit from env if set
 CC := $(CC)
 CXX := $(CXX)
-CFLAGS := $(CFLAGS)
-CXXFLAGS := $(CXXFLAGS) -std=c++11
+CFLAGS := $(CFLAGS) -MD
+CXXFLAGS := $(CXXFLAGS) -std=c++11 -MD
 LDFLAGS := $(LDFLAGS)
 WARNING_FLAGS := -Wall -Wshadow -Wsign-compare -Wextra -Wunreachable-code -Wuninitialized -Wshadow
 RELEASE_FLAGS := -O3 -DNDEBUG
@@ -41,8 +41,10 @@ man/tippecanoe.1: README.md
 
 PG=
 
+DEPS=$(wildcard *.d)
 H = $(wildcard *.h) $(wildcard *.hpp)
 C = $(wildcard *.c) $(wildcard *.cpp)
+OBJS = geojson.o jsonpull/jsonpull.o tile.o pool.o mbtiles.o geometry.o projection.o memfile.o mvt.o serial.o main.o text.o dirtiles.o plugin.o read_json.o write_json.o geobuf.o evaluator.o geocsv.o csv.o geojson-loop.o enumerate.o decode.o tile-join.o unit.o jsontool.o
 
 INCLUDES = -I/usr/local/include -I.
 LIBS = -L/usr/local/lib
@@ -65,7 +67,7 @@ tippecanoe-json-tool: jsontool.o jsonpull/jsonpull.o csv.o text.o geojson-loop.o
 unit: unit.o text.o
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3 -lpthread
 
--include $(wildcard *.d)
+-include $(OBJS:.o=.d)
 
 %.o: %.c
 	$(CC) -MMD $(PG) $(INCLUDES) $(FINAL_FLAGS) $(CFLAGS) -c -o $@ $<
@@ -74,7 +76,7 @@ unit: unit.o text.o
 	$(CXX) -MMD $(PG) $(INCLUDES) $(FINAL_FLAGS) $(CXXFLAGS) -c -o $@ $<
 
 clean:
-	rm -f ./tippecanoe ./tippecanoe-* ./tile-join ./unit *.o *.d */*.o */*.d tests/**/*.mbtiles tests/**/*.check
+	rm -f ./tippecanoe ./tippecanoe-* ./tile-join ./unit *.o *.d */*.o */*.d tests/**/*.mbtiles tests/**/*.check $(DEPS)
 
 indent:
 	clang-format -i -style="{BasedOnStyle: Google, IndentWidth: 8, UseTab: Always, AllowShortIfStatementsOnASingleLine: false, ColumnLimit: 0, ContinuationIndentWidth: 8, SpaceAfterCStyleCast: true, IndentCaseLabels: false, AllowShortBlocksOnASingleLine: false, AllowShortFunctionsOnASingleLine: false, SortIncludes: false}" $(C) $(H)


### PR DESCRIPTION
Hello

This pull request fixes the build script of this project.
Specifically, it adds missing Make dependencies so that the targets of the project are re-generated correctly whenever there are updates to any of the dependent source files.

In this way, the project is incrementally built and we no longer sacrifice time in clean builds (i.e., builds after a make clean).

Note that this fix follows the best practices for tracking dependencies automatically (through gcc -MD)

For more details, see here.
https://www.gnu.org/software/make/manual/html_node/Automatic-Prerequisites.html