### PR TITLE
Clean a few warnings emited by GCC v8

### DIFF
--- a/geometry.cpp
+++ b/geometry.cpp
@@ -270,7 +270,7 @@ drawvec clean_or_clip_poly(drawvec &geom, int z, int buffer, bool clip) {
 	mapbox::geometry::multi_polygon<long long> result;
 	try {
 		wagyu.execute(mapbox::geometry::wagyu::clip_type_union, result, mapbox::geometry::wagyu::fill_type_positive, mapbox::geometry::wagyu::fill_type_positive);
-	} catch (std::runtime_error e) {
+	} catch (std::runtime_error &e) {
 		FILE *f = fopen("/tmp/wagyu.log", "w");
 		fprintf(f, "%s\n", e.what());
 		fprintf(stderr, "%s\n", e.what());

--- a/jsontool.cpp
+++ b/jsontool.cpp
@@ -111,7 +111,7 @@ std::string sort_quote(const char *s) {
 
 	for (size_t i = 0; i < utf32.size(); i++) {
 		if (utf32[i] < 0xD800) {
-			char buf[7];
+			char buf[8];
 			sprintf(buf, "\\u%04lu", utf32[i]);
 			ret.append(std::string(buf));
 		} else {

--- a/mbtiles.cpp
+++ b/mbtiles.cpp
@@ -130,10 +130,7 @@ void tilestats(std::map<std::string, layermap_entry> const &layermap1, size_t el
 	state.json_write_string("layers");
 	state.json_write_array();
 
-	bool first = true;
 	for (auto layer : layermap) {
-		first = false;
-
 		state.nospace = true;
 		state.json_write_hash();
 
@@ -509,7 +506,6 @@ void mbtiles_write_metadata(sqlite3 *outdb, const char *outdir, const char *fnam
 			state.json_write_newline();
 
 			sqlite3_stmt *stmt;
-			bool first = true;
 			if (sqlite3_prepare_v2(db, "SELECT name, value from metadata;", -1, &stmt, NULL) == SQLITE_OK) {
 				while (sqlite3_step(stmt) == SQLITE_ROW) {
 					std::string key, value;
@@ -524,7 +520,6 @@ void mbtiles_write_metadata(sqlite3 *outdb, const char *outdir, const char *fnam
 					state.json_comma_newline();
 					state.json_write_string(k);
 					state.json_write_string(v);
-					first = false;
 				}
 				sqlite3_finalize(stmt);
 			}


### PR DESCRIPTION
An instance of catching an exception by value:

  https://blog.knatten.org/2010/04/02/always-catch-exceptions-by-reference/

In jsontool, there's a warning about writing 8 bytes into a 7
byte buffer, potentially truncating or losing the nul-terminator.

There are a couple of instances of an unused bool variable, not
really a big deal.