### PR TITLE
Instruct curl to follow redirects for census.gov URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -792,7 +792,7 @@ Example
 Imagine you have a tileset of census blocks:
 
 ```sh
-curl -O http://www2.census.gov/geo/tiger/TIGER2010/TABBLOCK/2010/tl_2010_06001_tabblock10.zip
+curl -L -O http://www2.census.gov/geo/tiger/TIGER2010/TABBLOCK/2010/tl_2010_06001_tabblock10.zip
 unzip tl_2010_06001_tabblock10.zip
 ogr2ogr -f GeoJSON tl_2010_06001_tabblock10.json tl_2010_06001_tabblock10.shp
 ./tippecanoe -o tl_2010_06001_tabblock10.mbtiles tl_2010_06001_tabblock10.json
@@ -801,7 +801,7 @@ ogr2ogr -f GeoJSON tl_2010_06001_tabblock10.json tl_2010_06001_tabblock10.shp
 and a CSV of their populations:
 
 ```sh
-curl -O http://www2.census.gov/census_2010/01-Redistricting_File--PL_94-171/California/ca2010.pl.zip
+curl -L -O http://www2.census.gov/census_2010/01-Redistricting_File--PL_94-171/California/ca2010.pl.zip
 unzip -p ca2010.pl.zip cageo2010.pl |
 awk 'BEGIN {
     print "GEOID10,population"


### PR DESCRIPTION
These examples are no longer working without the addition of `-L` to the `curl` command. Note that other examples in this same file already have the `-L` for `census.gov` URLs.

Example for URL being called:
```
> curl -I http://www2.census.gov/census_2010/01-Redistricting_File--PL_94-171/California/ca2010.pl.zip

HTTP/1.1 302 Moved Temporarily
Location: https://www2.census.gov/census_2010/01-Redistricting_File--PL_94-171/California/ca2010.pl.zip?sec_ak_reference=18.440ad717.1589950562.829e1048
Server: BigIP
Content-Length: 0
Date: Wed, 20 May 2020 04:56:02 GMT
Connection: keep-alive
```