### PR TITLE
Update image to prevent GLIBC_2.29 not found error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start from ubuntu
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 # Update repos and install dependencies
 RUN apt-get update \


### PR DESCRIPTION
When running the existing dockerfile as described

```
$ docker build -t tippecanoe:latest .
$ docker run -it --rm \
  -v /tiledata:/data \
  tippecanoe:latest \
  tippecanoe --output=/data/output.mbtiles /data/example.geojson
```
The following errors is thrown
```
tippecanoe: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by tippecanoe)
```

This is resolved by updating the dockerfile's ubuntu version to one which has a newer GLIBC.