### PR TITLE
Update Dockerfile to ubuntu:latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start from ubuntu
-FROM ubuntu:16.04
+FROM ubuntu:latest
 
 # Update repos and install dependencies
 RUN apt-get update \


### PR DESCRIPTION
I suggest update ubuntu version of Dockerfile as latest version.

Now Dockerfile of this project specify `FROM ubuntu:16.04`, that is not latest stable version.
Current latest LTS of Ubuntu is 20.04
But it will soon be update 22.04 at next April, 2022.

I believe ubuntu version will automatically upgrade 22.04 if we specify `FROM ubuntu:latest` in Dockerfile.

I've already checked this change works expectedly.

PS:
If you believe we should specify one of specific version of ubuntu for stability, Please close this pull request.