### PR TITLE
Remove Homebrew installation instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,8 @@ significant travel corridor.
 Installation
 ------------
 
-The easiest way to install tippecanoe on OSX is with [Homebrew](http://brew.sh/):
-
-```sh
-$ brew install tippecanoe
-```
+> NOTE: Homebrew no longer points to this project as of 2022-Oct-17 and has
+>  switched to the felt/tippecanoe repository that is actively maintained
 
 On Ubuntu it will usually be easiest to build from the source repository:
 


### PR DESCRIPTION
As of 2022-Oct-17, Homebrew no longer points to this repository, so those installation instructions have been removed.